### PR TITLE
Make custom change printer example more mature

### DIFF
--- a/examples/printers.hpp
+++ b/examples/printers.hpp
@@ -1,23 +1,25 @@
 #ifndef DTL_PRINTERS
 #define DTL_PRINTERS
 
+#include <dtl/dtl.hpp>
+
 template <typename sesElem, typename stream = ostream >
-class customChangePrinter : public Printer < sesElem, stream >
+class customChangePrinter : public dtl::Printer < sesElem, stream >
 {
 public :
-    customChangePrinter () : Printer < sesElem, stream > () {}
-    customChangePrinter (stream& out) : Printer < sesElem, stream > (out) {}
+    customChangePrinter () : dtl::Printer < sesElem, stream > () {}
+    customChangePrinter (stream& out) : dtl::Printer < sesElem, stream > (out) {}
     ~customChangePrinter () {}
     void operator() (const sesElem& se) const {
         switch (se.second.type) {
-        case SES_ADD:
-            this->out_ << "Add: " << se.first << endl;
+        case dtl::SES_ADD:
+            this->out_ << "Add: " << se.first << std::endl;
             break;
-        case SES_DELETE:
-            this->out_ << "Delete: " << se.first << endl;
+        case dtl::SES_DELETE:
+            this->out_ << "Delete: " << se.first << std::endl;
             break;
-        case SES_COMMON:
-            this->out_ << "Common: " << se.first << endl;
+        case dtl::SES_COMMON:
+            this->out_ << "Common: " << se.first << std::endl;
             break;
         }
     }

--- a/examples/strdiff_cp.cpp
+++ b/examples/strdiff_cp.cpp
@@ -1,19 +1,14 @@
-
 #include <dtl/dtl.hpp>
 #include "common.hpp"
 #include <iostream>
 #include <sstream>
 #include <string>
 
+#include "printers.hpp"
+
 using namespace std;
 
 using dtl::Diff;
-using dtl::SES_ADD;
-using dtl::SES_DELETE;
-using dtl::SES_COMMON;
-using dtl::Printer;
-
-#include "printers.hpp"
 
 int main(int argc, char *argv[]){
     


### PR DESCRIPTION
printers.hpp does not depend anymore on includes or usings order
inside strdiff_cp.cpp file.