### PR TITLE
Allow saving SES to provided data storage

### DIFF
--- a/dtl/Diff.hpp
+++ b/dtl/Diff.hpp
@@ -340,6 +340,15 @@ namespace dtl {
             sesElemVec ses_v = ses.getSequence ();
             for_each (ses_v.begin (), ses_v.end(), PT < sesElem, stream > (out));
         }
+
+        /**
+         * store difference between A and B as an SES with custom storage
+         */
+        template < typename storedData, template < typename SEET, typename STRT > class ST >
+        void storeSES(storedData& sd) const {
+            sesElemVec ses_v = ses.getSequence();
+            for_each(ses_v.begin(), ses_v.end(), ST < sesElem, storedData >(sd));
+        }
         
         /**
          * print difference between A and B in the Unified Format

--- a/dtl/functors.hpp
+++ b/dtl/functors.hpp
@@ -118,6 +118,20 @@ namespace dtl {
     private :
         stream& out_;
     };
+
+    /**
+     * storage class template
+     */
+    template <typename sesElem, typename storedData >
+    class Storage
+    {
+    public:
+        Storage(storedData& sd) : storedData_(sd) {}
+        virtual ~Storage() {}
+        virtual void operator() (const sesElem& se) const = 0;
+    protected:
+        storedData& storedData_;
+    };
     
     /**
      * compare class template

--- a/examples/SConstruct
+++ b/examples/SConstruct
@@ -26,17 +26,18 @@ for lib in libs:
 
 conf.Finish()
 
-targets = { 'strdiff'    : ['strdiff.cpp',    'common.cpp'], # diff between two string sequences
-            'intdiff'    : ['intdiff.cpp'],                  # diff between two integer sequences
-            'unidiff'    : ['unidiff.cpp',    'common.cpp'], # unified diff between two files
-            'unistrdiff' : ['unistrdiff.cpp', 'common.cpp'], # unified diff between two strings
-            'bdiff'      : ['bdiff.cpp',      'common.cpp'], # diff between two byte sequences
-            'strdiff3'   : ['strdiff3.cpp',   'common.cpp'], # three-way string diff program using dtl
-            'intdiff3'   : ['intdiff3.cpp'],                 # three-way integer diff program using dtl
-            'patch'      : ['patch.cpp',      'common.cpp'], # string patch program using dtl
-            'fpatch'     : ['fpatch.cpp',     'common.cpp'], # file patch program using dtl
-            'st2ses'     : ['st2ses.cpp',     'common.cpp'], # convert SES format file to SES instance
-            'strdiff_cp' : ['strdiff_cp.cpp', 'common.cpp'], # diff between two string sequences with custom printer
+targets = { 'strdiff'         : ['strdiff.cpp',         'common.cpp'], # diff between two string sequences
+            'intdiff'         : ['intdiff.cpp'],                       # diff between two integer sequences
+            'unidiff'         : ['unidiff.cpp',         'common.cpp'], # unified diff between two files
+            'unistrdiff'      : ['unistrdiff.cpp',      'common.cpp'], # unified diff between two strings
+            'bdiff'           : ['bdiff.cpp',           'common.cpp'], # diff between two byte sequences
+            'strdiff3'        : ['strdiff3.cpp',        'common.cpp'], # three-way string diff program using dtl
+            'intdiff3'        : ['intdiff3.cpp'],                      # three-way integer diff program using dtl
+            'patch'           : ['patch.cpp',           'common.cpp'], # string patch program using dtl
+            'fpatch'          : ['fpatch.cpp',          'common.cpp'], # file patch program using dtl
+            'st2ses'          : ['st2ses.cpp',          'common.cpp'], # convert SES format file to SES instance
+            'strdiff_cp'      : ['strdiff_cp.cpp',      'common.cpp'], # diff between two string sequences with custom printer
+            'strdiff_storage' : ['strdiff_storage.cpp', 'common.cpp'], # diff between two string sequences with custom storage
             }
 
 [ env.Program(target, targets[target]) for target in targets ]

--- a/examples/storage.hpp
+++ b/examples/storage.hpp
@@ -1,0 +1,27 @@
+#ifndef DTL_STORAGE
+#define DTL_STORAGE
+
+#include <dtl/dtl.hpp>
+
+template <typename sesElem, typename storedData >
+class CustomStorage : public dtl::Storage < sesElem, storedData >
+{
+public :
+    CustomStorage(storedData& sd) : dtl::Storage < sesElem, storedData > (sd) {}
+    ~CustomStorage() {}
+    void operator() (const sesElem& se) const {
+        switch (se.second.type) {
+        case dtl::SES_ADD:
+            this->storedData_ = this->storedData_ + "Add: " + se.first + "\n";
+            break;
+        case dtl::SES_DELETE:
+            this->storedData_ = this->storedData_ + "Delete: " + se.first + "\n";
+            break;
+        case dtl::SES_COMMON:
+            this->storedData_ = this->storedData_ + "Common: " + se.first + "\n";
+            break;
+        }
+    }
+};
+
+#endif // DTL_STORAGE

--- a/examples/strdiff_storage.cpp
+++ b/examples/strdiff_storage.cpp
@@ -1,0 +1,38 @@
+#include <dtl/dtl.hpp>
+#include "common.hpp"
+#include <iostream>
+#include <string>
+
+#include "storage.hpp"
+
+using namespace std;
+
+using dtl::Diff;
+
+int main(int argc, char *argv[]){
+    
+    if (isFewArgs(argc)) {
+        cerr << "Too few arguments." << endl;
+        return -1;
+    }
+    
+    typedef char   elem;
+    typedef string sequence;
+
+    sequence A(argv[1]);
+    sequence B(argv[2]);
+    
+    Diff< elem, sequence > d(A, B);
+    d.compose();
+    
+    // Shortest Edit Script
+    cout << "SES" << endl;
+
+    string result;
+
+    d.storeSES < string, CustomStorage > (result);
+
+    cout << result;
+    
+    return 0;
+}


### PR DESCRIPTION
It is not always efficient (or possible) to use standard output
streams. Moreover, such generated result may be now further
processed.