### PR TITLE
Travis-ci: added support for ppc64le along with amd64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: cpp
 compiler:
   - gcc
   - clang
+arch:
+  - amd64
+  - ppc64le
 before_script:
   - sudo apt-get install -y cmake scons
   - wget https://github.com/google/googletest/archive/release-1.8.0.zip


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/dtl/builds/187591092 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Thanks !!