### PR TITLE
Fix uninitialized scalar errors reported by Coverity:

### DIFF
--- a/dtl/Diff.hpp
+++ b/dtl/Diff.hpp
@@ -283,7 +283,7 @@ namespace dtl {
             
             editDistance += static_cast<long long>(delta) + 2 * p;
             long long r = path[delta+offset];
-            P cordinate;
+            P cordinate = {};
             editPathCordinates epc(0);
             
             // recording edit distance only
@@ -561,6 +561,8 @@ namespace dtl {
             trivial          = false;
             editDistanceOnly = false;
             fp               = NULL;
+            ox               = 0;
+            oy               = 0;
         }
         
         /**


### PR DESCRIPTION
A Coverity scan on my project, when including DTL, reported these errors:

uninit_use_in_call: Using uninitialized value cordinate. Field cordinate.k is uninitialized when calling push_back.

uninit_member: Non-static class member ox is not initialized in this constructor nor in any functions that it calls.

uninit_member: Non-static class member oy is not initialized in this constructor nor in any functions that it calls.

This PR fixes these issues.
Thanks!