### PR TITLE
Fix build with GCC 14.

### DIFF
--- a/dtl/Diff.hpp
+++ b/dtl/Diff.hpp
@@ -164,7 +164,7 @@ namespace dtl {
             return trivial;
         }
         
-        void enableTrivial () const {
+        void enableTrivial () {
             this->trivial = true;
         }
         


### PR DESCRIPTION
The method should not be const since it mutates the member field, which is not marked as mutable.