### PR TITLE
dtl/Diff.h: make method enableTrivial() non-const

### DIFF
--- a/dtl/Diff.hpp
+++ b/dtl/Diff.hpp
@@ -164,7 +164,7 @@ namespace dtl {
             return trivial;
         }
         
-        void enableTrivial () const {
+        void enableTrivial () {
             this->trivial = true;
         }
         


### PR DESCRIPTION
Did not compile with gcc-14.1 due to an attempt to assign to the member of const object
This change fixes the problem