### PR TITLE
Fix compile error seen with GCC-14.1.1 and Clang-17.0.6

### DIFF
--- a/dtl/Diff.hpp
+++ b/dtl/Diff.hpp
@@ -163,8 +163,8 @@ namespace dtl {
         bool trivialEnabled () const {
             return trivial;
         }
-        
-        void enableTrivial () const {
+
+        void enableTrivial () {
             this->trivial = true;
         }
         


### PR DESCRIPTION
```
/tmp/dtl/Diff.hpp: In member function 'void dtl::Diff<elem, sequence, comparator>::enableTrivial() const':
/tmp/dtl/Diff.hpp:168:27: error: assignment of member 'trivial' in read-only object
  168 |             this->trivial = true;
      |             ~~~~~~~~~~~~~~^~~~~~
```