### PR TITLE
ci: update googletest to 1.14.0.

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -12,9 +12,9 @@ jobs:
       run: |
         sudo apt-get install -y scons
         sudo apt-get install -y cmake scons
-        wget https://github.com/google/googletest/archive/release-1.14.0.zip
-        unzip -q release-1.14.0.zip
-        cd googletest-release-1.14.0
+        wget https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
+        tar zxvf v1.14.0.tar.gz
+        cd googletest-1.14.0
         cmake .
         make
         sudo make install

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -6,15 +6,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install scons and gtest
       run: |
         sudo apt-get install -y scons
         sudo apt-get install -y cmake scons
-        wget https://github.com/google/googletest/archive/release-1.11.0.zip
-        unzip -q release-1.11.0.zip
-        cd googletest-release-1.11.0
+        wget https://github.com/google/googletest/archive/release-1.14.0.zip
+        unzip -q release-1.14.0.zip
+        cd googletest-release-1.14.0
         cmake .
         make
         sudo make install

--- a/test/SConstruct
+++ b/test/SConstruct
@@ -11,7 +11,7 @@ def path_chomp(path):
 env  = Environment(
     CPPFLAGS=['-Wall', '-O2'],
     CPPPATH=['..'],
-	CXXFLAGS="-std=c++11",
+    CXXFLAGS="-std=c++14",
 )
 
 conf = Configure(env);


### PR DESCRIPTION
plus, 

- use actions/checkout@v4
- use c++14
  - googltest-1.14.x requires at least C++14